### PR TITLE
feat: add booking page and routes

### DIFF
--- a/src/pages/Book.jsx
+++ b/src/pages/Book.jsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+import { Box, CircularProgress, Alert } from "@mui/material"
+import ClassicBook from "../templates/classic/Book"
+import ModernBook from "../templates/modern/Book"
+
+const API_URL = import.meta.env.VITE_API_URL
+const TENANT = import.meta.env.VITE_TENANT_DOMAIN || window.location.host
+
+export default function Book({ cfg }) {
+  const key = (cfg.templateKey || "classic").toLowerCase()
+
+  const [hotel, setHotel] = React.useState(null)
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState(null)
+
+  React.useEffect(() => {
+    let isMounted = true
+    const ac = new AbortController()
+
+    async function run() {
+      setLoading(true)
+      setError(null)
+      try {
+        const resp = await fetch(`${API_URL}/tenants/webconstructor/hotel`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            "x-tenant-domain": TENANT,
+          },
+          signal: ac.signal,
+        })
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}))
+          throw new Error(data?.error || `HTTP ${resp.status}`)
+        }
+        const data = await resp.json()
+        if (isMounted) setHotel(data)
+      } catch (e) {
+          if (isMounted && e.name !== "AbortError") setError(e.message || "Fetch error")
+      } finally {
+        if (isMounted) setLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      isMounted = false
+      ac.abort()
+    }
+  }, [])
+
+  if (loading) {
+    return (
+      <Box p={3} display="flex" alignItems="center" gap={2}>
+        <CircularProgress size={22} /> Cargando hotel…
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box p={3}>
+        <Alert severity="error">No se pudo cargar el hotel: {error}</Alert>
+      </Box>
+    )
+  }
+
+    if (key === "classic") return <ClassicBook cfg={cfg} hotel={hotel} />
+    if (key === "modern") return <ModernBook cfg={cfg} hotel={hotel} />
+    return <Box p={3}>Plantilla no disponible: {key}</Box>
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,12 +1,14 @@
 import * as React from 'react'
 import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
+import Book from './pages/Book'
 import NotFound from './pages/NotFound'
 
 export default function AppRoutes({ cfg }) {
   return (
     <Routes>
       <Route path="/" element={<Home cfg={cfg} />} />
+      <Route path="/book" element={<Book cfg={cfg} />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   )

--- a/src/templates/Classic.jsx
+++ b/src/templates/Classic.jsx
@@ -34,6 +34,7 @@ import ShoppingCartOutlinedIcon from "@mui/icons-material/ShoppingCartOutlined"
 import MenuIcon from "@mui/icons-material/Menu"
 import HotelIcon from "@mui/icons-material/Hotel"
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline"
+import { Link as RouterLink } from "react-router-dom"
 
 // ------------ helpers ------------
 const getDescription = (descriptions, langPref = "es") => {
@@ -99,7 +100,7 @@ export default function Classic({ cfg = {}, hotel = {} }) {
       ex.heroImage ||
       "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?q=80&w=1800&auto=format&fit=crop",
     ctaText: ex.heroCtaText || "BOOK NOW",
-    ctaHref: ex.heroCtaHref || "#book",
+    ctaHref: ex.heroCtaHref || "/book",
   }
 
   const theme = createTheme({
@@ -419,7 +420,8 @@ export default function Classic({ cfg = {}, hotel = {} }) {
               {hero.subtitle}
             </Typography>
             <Button
-              href={hero.ctaHref}
+              component={RouterLink}
+              to={hero.ctaHref}
               size="large"
               sx={{
                 mt: 3,

--- a/src/templates/Modern.jsx
+++ b/src/templates/Modern.jsx
@@ -35,6 +35,7 @@ import HotelOutlinedIcon from "@mui/icons-material/HotelOutlined"
 import VerifiedOutlinedIcon from "@mui/icons-material/VerifiedOutlined"
 import AccessTimeOutlinedIcon from "@mui/icons-material/AccessTimeOutlined"
 import MapOutlinedIcon from "@mui/icons-material/MapOutlined"
+import { Link as RouterLink } from "react-router-dom"
 
 // ---------- helpers ----------
 const getDescription = (descriptions, langPref = "en") => {
@@ -132,7 +133,7 @@ export default function Modern({ cfg = {}, hotel = {} }) {
       ex.heroImage ||
       "https://images.unsplash.com/photo-1528909514045-2fa4ac7a08ba?q=80&w=1800&auto=format&fit=crop",
     ctaText: ex.heroCtaText || "Book now",
-    ctaHref: ex.heroCtaHref || "#contact",
+    ctaHref: ex.heroCtaHref || "/book",
   }
 
   const address = fullAddress(hotel?.location)
@@ -230,7 +231,7 @@ export default function Modern({ cfg = {}, hotel = {} }) {
                     <ShoppingCartOutlinedIcon />
                   </Badge>
                 </IconButton>
-                <Button variant="contained" href={hero.ctaHref}>
+                <Button variant="contained" component={RouterLink} to={hero.ctaHref}>
                   {hero.ctaText}
                 </Button>
                 <IconButton onClick={toggle} sx={{ display: { md: "none" } }}>
@@ -282,7 +283,7 @@ export default function Modern({ cfg = {}, hotel = {} }) {
                 <Chip icon={<HotelOutlinedIcon />} label="Curated rooms" />
               </Stack>
               <Stack direction="row" spacing={1.5} sx={{ mt: 4 }}>
-                <Button variant="contained" size="large" href={hero.ctaHref}>
+                <Button variant="contained" size="large" component={RouterLink} to={hero.ctaHref}>
                   {hero.ctaText}
                 </Button>
                 <Button variant="outlined" size="large" href="#rooms">

--- a/src/templates/classic/Book.jsx
+++ b/src/templates/classic/Book.jsx
@@ -1,0 +1,37 @@
+import * as React from "react"
+import { ThemeProvider, createTheme } from "@mui/material/styles"
+import { Box, Typography, CssBaseline } from "@mui/material"
+
+export default function ClassicBook({ cfg = {}, hotel = {} }) {
+  const primary = cfg.primaryColor || "#d4af37"
+  const secondary = cfg.secondaryColor || "#0b0e13"
+  const font = cfg.fontFamily || "Inter, system-ui, sans-serif"
+
+  const theme = createTheme({
+    typography: { fontFamily: font },
+    palette: {
+      mode: 'dark',
+      primary: { main: primary },
+      background: { default: secondary, paper: secondary },
+    },
+    components: {
+      MuiButton: {
+        styleOverrides: {
+          root: { borderRadius: 12, textTransform: 'none', fontWeight: 800 },
+        },
+      },
+    },
+  })
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Box sx={{ bgcolor: secondary, color: "#fff", minHeight: "100vh", p: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          Book your stay {hotel?.hotelName ? `at ${hotel.hotelName}` : ""}
+        </Typography>
+        <Typography>Classic booking page placeholder.</Typography>
+      </Box>
+    </ThemeProvider>
+  )
+}

--- a/src/templates/modern/Book.jsx
+++ b/src/templates/modern/Book.jsx
@@ -1,0 +1,51 @@
+import * as React from "react"
+import { ThemeProvider, createTheme } from "@mui/material/styles"
+import { Box, Typography, CssBaseline } from "@mui/material"
+
+export default function ModernBook({ cfg = {}, hotel = {} }) {
+  const primary = cfg.primaryColor || "#0EA5E9"
+  const surface = "#ffffff"
+  const background = cfg.secondaryColor || "#F6F7FB"
+  const font = cfg.fontFamily || "Inter, system-ui, sans-serif"
+
+  const theme = createTheme({
+      palette: {
+        mode: "light",
+        primary: { main: primary },
+        background: { default: background, paper: surface },
+        text: { primary: "#0F172A", secondary: "#475569" },
+      },
+      shape: { borderRadius: 16 },
+      typography: {
+        fontFamily: font,
+        h2: { fontWeight: 900, letterSpacing: 0.2 },
+        h4: { fontWeight: 800 },
+        button: { textTransform: "none", fontWeight: 800 },
+      },
+    components: {
+        MuiPaper: {
+          styleOverrides: {
+            root: { border: "1px solid rgba(2,6,23,0.06)" },
+          },
+        },
+        MuiButton: {
+          styleOverrides: { root: { borderRadius: 12 } },
+        },
+        MuiAppBar: {
+          styleOverrides: { root: { backdropFilter: "saturate(140%) blur(6px)" } },
+        },
+    },
+  })
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+        <Box sx={{ minHeight: "100vh", bgcolor: background, color: "text.primary", p: 4 }}>
+          <Typography variant="h4" gutterBottom>
+            Book your stay {hotel?.hotelName ? `at ${hotel.hotelName}` : ""}
+          </Typography>
+          <Typography>Modern booking page placeholder.</Typography>
+        </Box>
+    </ThemeProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- add booking page that chooses classic or modern template and fetches hotel data
- create template-specific booking components with matching themes
- route booking CTA buttons to `/book`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5e85f73c08329a68d62ae42432fd2