### PR TITLE
Forward optionRefId for booking APIs

### DIFF
--- a/src/api/booking.js
+++ b/src/api/booking.js
@@ -1,6 +1,13 @@
 // src/api/booking.js
-const API_URL = import.meta.env.VITE_API_URL
-const TENANT = import.meta.env.VITE_TENANT_DOMAIN || window.location.host
+// Allow running in non-Vite environments (e.g. Node tests)
+const API_URL =
+  (import.meta.env && import.meta.env.VITE_API_URL) ||
+  (typeof process !== 'undefined' && process.env.VITE_API_URL) ||
+  ''
+const TENANT =
+  (import.meta.env && import.meta.env.VITE_TENANT_DOMAIN) ||
+  (typeof process !== 'undefined' && process.env.VITE_TENANT_DOMAIN) ||
+  (typeof window !== 'undefined' ? window.location.host : '')
 
 function buildHeaders(extra = {}) {
   return {

--- a/src/api/booking.test.js
+++ b/src/api/booking.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// Setup environment expected by booking.js
+process.env.VITE_API_URL = 'https://api.test'
+process.env.VITE_TENANT_DOMAIN = 'tenant.test'
+// window may be referenced when TENANT fallback is used
+global.window = { location: { host: 'tenant.test' } }
+
+// Mock fetch to capture request bodies
+let lastFetch
+global.fetch = async (url, opts) => {
+  lastFetch = { url, opts }
+  return {
+    ok: true,
+    headers: { get: () => 'application/json' },
+    json: async () => ({})
+  }
+}
+
+const { tgxCreatePaymentIntent, tgxBookWithCard } = await import('./booking.js')
+
+test('tgxCreatePaymentIntent forwards optionRefId', async () => {
+  const optionRefId = 'opt-123'
+  await tgxCreatePaymentIntent({ optionRefId, bookingData: {} })
+  const body = JSON.parse(lastFetch.opts.body)
+  assert.equal(body.optionRefId, optionRefId)
+})
+
+test('tgxBookWithCard forwards optionRefId', async () => {
+  const optionRefId = 'opt-456'
+  await tgxBookWithCard({ optionRefId, bookingData: {} })
+  const body = JSON.parse(lastFetch.opts.body)
+  assert.equal(body.optionRefId, optionRefId)
+})

--- a/src/components/BookingForm.jsx
+++ b/src/components/BookingForm.jsx
@@ -76,6 +76,9 @@ export default function BookingForm({ cfg = {}, hotel = {}, compact = false }) {
         if (cancelled) return
         const np = res?.numberOfPax ?? res?.option?.numberOfPax
         if (Number.isFinite(np)) setNumberOfPax(Number(np))
+        if (res?.optionRefId) {
+          setForm((s) => (s.optionRefId === res.optionRefId ? s : { ...s, optionRefId: res.optionRefId }))
+        }
       } catch (err) {
         console.error('Failed to fetch option details', err)
       }
@@ -157,7 +160,7 @@ export default function BookingForm({ cfg = {}, hotel = {}, compact = false }) {
             children: Number(form.children || 0),
             roomId: null,
           },
-          searchOptionRefId: String(form.optionRefId || '').trim(),
+          optionRefId: String(form.optionRefId || '').trim(),
           source: 'TGX',
         }, { vaultExtra: { vaultKey: 'demo', pageUrl: window.location.href } })
 


### PR DESCRIPTION
## Summary
- Persist optionRefId from quotes and reuse it for subsequent booking calls
- Send optionRefId when creating payment intents and booking with card
- Add tests ensuring the optionRefId is forwarded to the API

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b72ccb62f88329b60d27377d9a0ae9